### PR TITLE
Primitive Fix

### DIFF
--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -29,7 +29,7 @@ const parsePrimitive = (name, definition) => {
   const res = [];
   const typeCell = 'type' in definition ? definition.type : '';
   const descriptionCell = 'description' in definition ? definition.description : '';
-  const requiredCell = 'required' in definition ? definition.required : '';
+  const requiredCell = '';
   res.push(`| ${name} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
   return res;
 };

--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -3,20 +3,13 @@ const inArray = require('../lib/inArray');
 const Schema = require('../models/schema');
 
 /**
- * @param {type} name
- * @param {type} definition
- * @return {type} Description
+ * If Property field is present parse them.
+ * @param name of the definition
+ * @param definition definition object
  */
-const processDefinition = (name, definition) => {
-  const res = [];
+const parseProperties = (name, definition) => {
   const required = 'required' in definition ? definition.required : [];
-
-  // Add anchor with name
-  res.push('');
-  res.push(`### ${name}  `);
-  res.push('');
-  res.push('| Name | Type | Description | Required |');
-  res.push('| ---- | ---- | ----------- | -------- |');
+  const res = [];
   Object.keys(definition.properties).map(propName => {
     const prop = definition.properties[propName];
     const typeCell = dataTypeTransformer(new Schema(prop));
@@ -24,11 +17,47 @@ const processDefinition = (name, definition) => {
     const requiredCell = inArray(propName, required) ? 'Yes' : 'No';
     res.push(`| ${propName} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
   });
+  return res;
+};
+
+/**
+ * Parse allOf defintion
+ * @param name of the definition
+ * @param definition definition object
+ */
+const parsePrimitive = (name, definition) => {
+  const res = [];
+  const typeCell = 'type' in definition ? definition.type : '';
+  const descriptionCell = 'description' in definition ? definition.description : '';
+  const requiredCell = 'required' in definition ? definition.required : '';
+  res.push(`| ${name} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
+  return res;
+};
+
+/**
+ * @param {type} name
+ * @param {type} definition
+ * @return {type} Description
+ */
+const processDefinition = (name, definition) => {
+  let res = [];
+  let parsedDef = [];
+  res.push('');
+  res.push(`### ${name}  `);
+  res.push('');
+  res.push('| Name | Type | Description | Required |');
+  res.push('| ---- | ---- | ----------- | -------- |');
+
+  if ('properties' in definition) {
+    parsedDef = parseProperties(name, definition);
+  } else {
+    parsedDef = parsePrimitive(name, definition);
+  }
+  res = res.concat(parsedDef);
 
   return res.length ? res.join('\n') : null;
 };
 module.exports.processDefinition = processDefinition;
-
 
 /**
  * @param {type} definitions

--- a/tests/transformers/definitions.spec.js
+++ b/tests/transformers/definitions.spec.js
@@ -5,20 +5,25 @@ const fixture = require('./definitionsFixture');
 describe('Definitions', () => {
   const res1 = transformDefinitions(fixture.data1).split('\n');
   const res2 = transformDefinitions(fixture.data2).split('\n');
+  const res3 = transformDefinitions(fixture.data3).split('\n');
   // Slice off header
   const res11 = res1.slice(6);
   const res12 = res2.slice(6);
+  const res13 = res3.slice(6);
 
   it('should create model header', () => {
     expect(fixture.definitionsHeader[0]).to.be.equal(res1[0]);
     expect(fixture.definitionsHeader[1]).to.be.equal(res1[1]);
     expect(fixture.definitionsHeader[0]).to.be.equal(res2[0]);
     expect(fixture.definitionsHeader[1]).to.be.equal(res2[1]);
+    expect(fixture.definitionsHeader[0]).to.be.equal(res3[0]);
+    expect(fixture.definitionsHeader[1]).to.be.equal(res3[1]);
   });
 
   it('should create proper header', () => {
     expect(fixture.defHeader1).to.be.equal(res1[3]);
     expect(fixture.defHeader2).to.be.equal(res2[3]);
+    expect(fixture.defHeader3).to.be.equal(res3[3]);
   });
 
   it('should create table headers', () => {
@@ -26,6 +31,8 @@ describe('Definitions', () => {
     expect(fixture.tableHeader[1]).to.be.equal(res1[6]);
     expect(fixture.tableHeader[0]).to.be.equal(res2[5]);
     expect(fixture.tableHeader[1]).to.be.equal(res2[6]);
+    expect(fixture.tableHeader[0]).to.be.equal(res3[5]);
+    expect(fixture.tableHeader[1]).to.be.equal(res3[6]);
   });
 
   describe('Simple data', () => {
@@ -47,6 +54,11 @@ describe('Definitions', () => {
     });
     it('should render array of references', () => {
       expect(res12[4]).to.be.equal(fixture.result2[3]);
+    });
+  });
+  describe('Primitive data', () => {
+    it('should create simple valid primitive table', () => {
+      expect(res13[1]).to.be.equal(fixture.result3[0]);
     });
   });
 });

--- a/tests/transformers/definitionsFixture.js
+++ b/tests/transformers/definitionsFixture.js
@@ -57,9 +57,20 @@ const fixture = {
     '| name | string | pet category in the store | Yes |',
     '| photoUrls | [ string ] |  | Yes |',
     '| tags | [ [Category](#category) ] |  | No |'
+  ],
+  data3: {
+    deviceid: {
+      type: 'integer',
+      format: 'int32',
+      description: 'DeviceID'
+    }
+  },
+  result3: [
+    '| deviceid | integer | DeviceID |  |'
   ]
 };
 fixture.defHeader1 = '### Tag  ';
 fixture.defHeader2 = '### Pet  ';
+fixture.defHeader3 = '### deviceid  ';
 
 module.exports = fixture;


### PR DESCRIPTION
primitive types are allowed in definitions. 

ie 
```
customer_id:
  type: "integer"
  format: "int32"
  description: "Customer Identifier"
```

this also solves some of the [TypeError: Cannot convert undefined or null to object] issues.

If at a later state you want to implement anyOf, allOf or oneOf. you can do so by just implementing a helper function to do the heavy lifting. 
