### PR TITLE
bugfix for input .yml (not .yaml)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -34,7 +34,7 @@ if (args.input) {
 
   try {
     const inputDoc = yaml.safeLoad(fs.readFileSync(args.input, 'utf8'));
-    const outputFile = args.output || args.input.replace(/(yaml|json)$/i, 'md');
+    const outputFile = args.output || args.input.replace(/(yaml|yml|json)$/i, 'md');
 
     // Collect parameters
     const parameters = ('parameters' in inputDoc) ? inputDoc.parameters : {};


### PR DESCRIPTION
when the input file has a .yml extension (not a .yaml) the input file get overwritten.
I added the yml extension the the replace regex for the output file.