### PR TITLE
Emit model descriptions if available.

### DIFF
--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -15,6 +15,10 @@ const processDefinition = (name, definition) => {
   res.push('');
   res.push(`### ${name}  `);
   res.push('');
+  if (definition.description) {
+    res.push(definition.description);
+    res.push('');
+  }
   res.push('| Name | Type | Description | Required |');
   res.push('| ---- | ---- | ----------- | -------- |');
   Object.keys(definition.properties).map(propName => {


### PR DESCRIPTION
This is just a chopped down version of PR #94 that implements only the model-definition change, so we can hopefully get this part pushed through.