### PR TITLE
Consistent use of markdown #-based headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -43,7 +43,7 @@ const processDefinition = (name, definition) => {
   let res = [];
   let parsedDef = [];
   res.push('');
-  res.push(`### ${name}  `);
+  res.push(`#### ${name}`);
   res.push('');
   if (definition.description) {
     res.push(definition.description);
@@ -74,8 +74,7 @@ module.exports = definitions => {
     definitions[definitionName]
   )));
   if (res.length > 0) {
-    res.unshift('---');
-    res.unshift('### Models');
+    res.unshift('### Models\n');
     return res.join('\n');
   }
   return null;

--- a/app/transformers/info.js
+++ b/app/transformers/info.js
@@ -12,7 +12,7 @@ module.exports = info => {
   const res = [];
   if (info !== null && typeof info === 'object') {
     if ('title' in info) {
-      res.push(`${info.title}\n${Array(info.title.length + 1).join('=')}`);
+      res.push(`# ${info.title}`);
     }
 
     if ('description' in info) {
@@ -20,11 +20,11 @@ module.exports = info => {
     }
 
     if ('version' in info) {
-      res.push(`**Version:** ${info.version}\n`);
+      res.push(`## Version: ${info.version}\n`);
     }
 
     if ('termsOfService' in info) {
-      res.push(`**Terms of service:**  \n${info.termsOfService}\n`);
+      res.push(`### Terms of service\n${info.termsOfService}\n`);
     }
 
     if ('contact' in info) {

--- a/app/transformers/path.js
+++ b/app/transformers/path.js
@@ -15,8 +15,7 @@ module.exports = (path, data, parameters) => {
 
   if (path && data) {
     // Make path as a header
-    res.push(`### ${path}`);
-    res.push('---');
+    res.push(`### ${path}\n`);
 
     // Check if parameter for path are in the place
     if ('parameters' in data) {
@@ -27,17 +26,17 @@ module.exports = (path, data, parameters) => {
     Object.keys(data).map(method => {
       if (inArray(method, ALLOWED_METHODS)) {
         // Set method as a subheader
-        res.push(`##### ***${method.toUpperCase()}***`);
+        res.push(`#### ${method.toUpperCase()}`);
         const pathInfo = data[method];
 
         // Set summary
         if ('summary' in pathInfo) {
-          res.push(`**Summary:** ${pathInfo.summary}\n`);
+          res.push(`##### Summary:\n\n${pathInfo.summary}\n`);
         }
 
         // Set description
         if ('description' in pathInfo) {
-          res.push(`**Description:** ${pathInfo.description}\n`);
+          res.push(`##### Description:\n\n${pathInfo.description}\n`);
         }
 
         // Build parameters

--- a/app/transformers/pathParameters.js
+++ b/app/transformers/pathParameters.js
@@ -3,7 +3,7 @@ const Schema = require('../models/schema');
 
 module.exports = (parameters, pathParameters, globalParameters = {}) => {
   const res = [];
-  res.push('**Parameters**\n');
+  res.push('##### Parameters\n');
   res.push('| Name | Located in | Description | Required | Schema |');
   res.push('| ---- | ---------- | ----------- | -------- | ---- |');
   [].concat(pathParameters, parameters).map(keys => {

--- a/app/transformers/pathResponses.js
+++ b/app/transformers/pathResponses.js
@@ -38,7 +38,7 @@ module.exports = responses => {
   });
   res.unshift(`| ---- | ----------- |${schemas ? ' ------ |' : ''}`);
   res.unshift(`| Code | Description |${schemas ? ' Schema |' : ''}`);
-  res.unshift('**Responses**\n');
+  res.unshift('##### Responses\n');
 
   return res.join('\n');
 };

--- a/app/transformers/security.js
+++ b/app/transformers/security.js
@@ -31,7 +31,7 @@ module.exports = security => {
       line.push(' ');
     }
     res.unshift(`|${line.join('|')}|`);
-    res.unshift('**Security**\n');
+    res.unshift('##### Security\n');
     return res.join('\n');
   }
   return null;

--- a/app/transformers/securityDefinitions.js
+++ b/app/transformers/securityDefinitions.js
@@ -37,7 +37,6 @@ module.exports = securityDefinitions => {
   // Create header
   // Only in case if there is some data
   if (res.length > 0) {
-    res.unshift('---');
     res.unshift('### Security');
   }
 

--- a/tests/transformers/definitions.spec.js
+++ b/tests/transformers/definitions.spec.js
@@ -13,11 +13,8 @@ describe('Definitions', () => {
 
   it('should create model header', () => {
     expect(fixture.definitionsHeader[0]).to.be.equal(res1[0]);
-    expect(fixture.definitionsHeader[1]).to.be.equal(res1[1]);
     expect(fixture.definitionsHeader[0]).to.be.equal(res2[0]);
-    expect(fixture.definitionsHeader[1]).to.be.equal(res2[1]);
     expect(fixture.definitionsHeader[0]).to.be.equal(res3[0]);
-    expect(fixture.definitionsHeader[1]).to.be.equal(res3[1]);
   });
 
   it('should create proper header', () => {

--- a/tests/transformers/definitionsFixture.js
+++ b/tests/transformers/definitionsFixture.js
@@ -1,6 +1,6 @@
 const fixture = {
   definitionsHeader: [
-    '### Models', '---'
+    '### Models'
   ],
   tableHeader: [
     '| Name | Type | Description | Required |',
@@ -69,8 +69,8 @@ const fixture = {
     '| deviceid | integer | DeviceID |  |'
   ]
 };
-fixture.defHeader1 = '### Tag  ';
-fixture.defHeader2 = '### Pet  ';
-fixture.defHeader3 = '### deviceid  ';
+fixture.defHeader1 = '#### Tag';
+fixture.defHeader2 = '#### Pet';
+fixture.defHeader3 = '#### deviceid';
 
 module.exports = fixture;

--- a/tests/transformers/info.spec.js
+++ b/tests/transformers/info.spec.js
@@ -16,9 +16,9 @@ describe('Info transformer', () => {
     };
 
     const res = transformInfo(fixture).split('\n');
-    expect(res[0]).to.be.equal(fixture.title);
+    expect(res[0]).to.be.equal(`# ${fixture.title}`);
     // Underline is same length as a title
-    expect(res[1]).to.be.equal(results.underline);
+    expect(res[1]).to.be.not.equal(results.underline);
   });
 
   it('should return description as is', () => {
@@ -35,10 +35,9 @@ describe('Info transformer', () => {
       description: 'Document description',
       version: '1.0.1'
     };
-    const result = 'Document title\n' +
-      '==============\n' +
+    const result = '# Document title\n' +
       'Document description\n\n' +
-      '**Version:** 1.0.1\n';
+      '## Version: 1.0.1\n';
     const res = transformInfo(fixture);
     expect(res).to.be.equal(result);
   });
@@ -47,7 +46,7 @@ describe('Info transformer', () => {
     const fixture = {
       termsOfService: 'Terms of service'
     };
-    const result = `**Terms of service:**  \n${fixture.termsOfService}\n`;
+    const result = `### Terms of service\n${fixture.termsOfService}\n`;
     const res = transformInfo(fixture);
     expect(res).to.be.equal(result);
   });

--- a/tests/transformers/path.spec.js
+++ b/tests/transformers/path.spec.js
@@ -12,8 +12,7 @@ describe('Path transformer', () => {
       path: '/status',
       data: {}
     };
-    const result = '### /status\n' +
-      '---';
+    const result = '### /status\n';
     const res = transformPath(fixture.path, fixture.data);
     expect(res).to.be.equal(result);
   });
@@ -25,7 +24,7 @@ describe('Path transformer', () => {
         get: {}
       }
     };
-    const result = '##### ***GET***';
+    const result = '#### GET';
     const res = transformPath(fixture.path, fixture.data).split('\n');
     expect(res[2]).to.be.equal(result);
   });
@@ -39,9 +38,11 @@ describe('Path transformer', () => {
         }
       }
     };
-    const result = '**Summary:** Summary text';
+    const result = '##### Summary:\n\nSummary text'.split('\n');
     const res = transformPath(fixture.path, fixture.data).split('\n');
-    expect(res[3]).to.be.equal(result);
+    expect(res[3]).to.be.equal(result[0]);
+    expect(res[4]).to.be.equal(result[1]);
+    expect(res[5]).to.be.equal(result[2]);
   });
 
   it('should render description if present', () => {
@@ -53,8 +54,10 @@ describe('Path transformer', () => {
         }
       }
     };
-    const result = '**Description:** Description text';
+    const result = '##### Description:\n\nDescription text'.split('\n');
     const res = transformPath(fixture.path, fixture.data).split('\n');
-    expect(res[3]).to.be.equal(result);
+    expect(res[3]).to.be.equal(result[0]);
+    expect(res[4]).to.be.equal(result[1]);
+    expect(res[5]).to.be.equal(result[2]);
   });
 });

--- a/tests/transformers/pathParameters.spec.js
+++ b/tests/transformers/pathParameters.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const parameters = require('../../app/transformers/pathParameters');
 
 const tableFixture = [
-  '**Parameters**',
+  '##### Parameters',
   '| Name | Located in | Description | Required | Schema |',
   '| ---- | ---------- | ----------- | -------- | ---- |'
 ];

--- a/tests/transformers/pathResponses.spec.js
+++ b/tests/transformers/pathResponses.spec.js
@@ -8,7 +8,7 @@ describe('Path responses transformer', () => {
       404: {}
     };
     const results = [
-      '**Responses**',
+      '##### Responses',
       '| Code | Description |',
       '| ---- | ----------- |',
       '| 200 | 200 |',
@@ -44,7 +44,7 @@ describe('Path responses transformer', () => {
       500: {}
     };
     const results = [
-      '**Responses**',
+      '##### Responses',
       '| Code | Description | Schema |',
       '| ---- | ----------- | ------ |',
       '| 200 | Echo GET | [Foo](#foo) |',
@@ -76,7 +76,7 @@ describe('Path responses transformer', () => {
       }
     };
     const results = [
-      '**Responses**',
+      '##### Responses',
       '| Code | Description | Schema |',
       '| ---- | ----------- | ------ |',
       '| 200 |  |  |',

--- a/tests/transformers/security.spec.js
+++ b/tests/transformers/security.spec.js
@@ -6,7 +6,7 @@ const fixture = [
     security: [{
       auth: []
     }],
-    result: '**Security**\n\n'
+    result: '##### Security\n\n'
             + '| Security Schema | Scopes |\n'
             + '| --- | --- |\n'
             + '| auth | |'
@@ -14,7 +14,7 @@ const fixture = [
     security: [{
       auth: ['write_pets', 'read_pets']
     }],
-    result: '**Security**\n\n'
+    result: '##### Security\n\n'
             + '| Security Schema | Scopes | |\n'
             + '| --- | --- | --- |\n'
             + '| auth | write_pets | read_pets |'

--- a/tests/transformers/securityDefinitions.spec.js
+++ b/tests/transformers/securityDefinitions.spec.js
@@ -13,7 +13,7 @@ describe('Security definitions', () => {
     Object.keys(typeResolver).map(type => {
       const fixture = { auth: { type } };
       const res = transformSecurituDefinitions(fixture);
-      const result = '### Security\n---\n'
+      const result = '### Security\n'
         + '**auth**  \n\n'
         + `|${type}|*${typeResolver[type]}*|\n`
         + '|---|---|\n';


### PR DESCRIPTION
Addresses issue-64 by consistently using #-based headings in the markdown. Also cleaned up the headings so that `##` used Version, `###` for API paths and `####` and `#####` respectives for headings below. I fixed the tests to make sure `npm run-script test` succeeds as well.