### PR TITLE
fix(definitions): Replace newlines with spaces in table

### DIFF
--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -13,7 +13,7 @@ const parseProperties = (name, definition) => {
   Object.keys(definition.properties).map(propName => {
     const prop = definition.properties[propName];
     const typeCell = dataTypeTransformer(new Schema(prop));
-    const descriptionCell = 'description' in prop ? prop.description : '';
+    const descriptionCell = ('description' in prop ? prop.description : '').replace(/[\r\n]/g, ' ');
     const requiredCell = inArray(propName, required) ? 'Yes' : 'No';
     res.push(`| ${propName} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
   });
@@ -21,14 +21,14 @@ const parseProperties = (name, definition) => {
 };
 
 /**
- * Parse allOf defintion
+ * Parse allOf definition
  * @param name of the definition
  * @param definition definition object
  */
 const parsePrimitive = (name, definition) => {
   const res = [];
   const typeCell = 'type' in definition ? definition.type : '';
-  const descriptionCell = 'description' in definition ? definition.description : '';
+  const descriptionCell = ('description' in definition ? definition.description : '').replace(/[\r\n]/g, ' ');
   const requiredCell = '';
   res.push(`| ${name} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
   return res;

--- a/app/transformers/pathParameters.js
+++ b/app/transformers/pathParameters.js
@@ -8,37 +8,37 @@ module.exports = (parameters, pathParameters, globalParameters = {}) => {
   res.push('| ---- | ---------- | ----------- | -------- | ---- |');
   [].concat(pathParameters, parameters).map(keys => {
     if (keys) {
-      let paramsetersKeys = keys;
+      let parametersKeys = keys;
       // Check it for the reference
       if ('$ref' in keys) {
         const ref = (keys.$ref).replace(/^#\/parameters\//, '');
         if (ref in globalParameters) {
-          paramsetersKeys = globalParameters[ref];
+          parametersKeys = globalParameters[ref];
         }
       }
       const line = [];
       // Name first
-      line.push(paramsetersKeys.name || '');
+      line.push(parametersKeys.name || '');
       // Scope (in)
-      line.push(paramsetersKeys.in || '');
+      line.push(parametersKeys.in || '');
       // description
-      if ('description' in paramsetersKeys) {
-        line.push(paramsetersKeys.description.replace(/[\r\n]/g, ' '));
+      if ('description' in parametersKeys) {
+        line.push(parametersKeys.description.replace(/[\r\n]/g, ' '));
       } else {
         line.push('');
       }
-      line.push(paramsetersKeys.required ? 'Yes' : 'No');
+      line.push(parametersKeys.required ? 'Yes' : 'No');
 
       // Prepare schema to be transformed
       let schema = null;
-      if ('schema' in paramsetersKeys) {
-        schema = new Schema(paramsetersKeys.schema);
+      if ('schema' in parametersKeys) {
+        schema = new Schema(parametersKeys.schema);
       } else {
         schema = new Schema();
-        schema.setType('type' in paramsetersKeys ? paramsetersKeys.type : null);
-        schema.setFormat('format' in paramsetersKeys ? paramsetersKeys.format : null);
-        schema.setReference('$ref' in paramsetersKeys ? paramsetersKeys.$ref : null);
-        schema.setItems('items' in paramsetersKeys ? paramsetersKeys.items : null);
+        schema.setType('type' in parametersKeys ? parametersKeys.type : null);
+        schema.setFormat('format' in parametersKeys ? parametersKeys.format : null);
+        schema.setReference('$ref' in parametersKeys ? parametersKeys.$ref : null);
+        schema.setItems('items' in parametersKeys ? parametersKeys.items : null);
       }
 
       line.push(transformDataTypes(schema));

--- a/tests/transformers/definitions.spec.js
+++ b/tests/transformers/definitions.spec.js
@@ -6,10 +6,12 @@ describe('Definitions', () => {
   const res1 = transformDefinitions(fixture.data1).split('\n');
   const res2 = transformDefinitions(fixture.data2).split('\n');
   const res3 = transformDefinitions(fixture.data3).split('\n');
+  const res4 = transformDefinitions(fixture.data4).split('\n');
   // Slice off header
   const res11 = res1.slice(6);
   const res12 = res2.slice(6);
   const res13 = res3.slice(6);
+  const res41 = res4.slice(-1);
 
   it('should create model header', () => {
     expect(fixture.definitionsHeader[0]).to.be.equal(res1[0]);
@@ -36,6 +38,10 @@ describe('Definitions', () => {
     expect(fixture.data3.deviceid.description).to.be.equal(res3[5]);
   });
 
+  it('should create a single description line', () => {
+    expect(res41[0]).to.be.equal(fixture.result4[0]);
+  });
+
   describe('Simple data', () => {
     it('should create simple valid table', () => {
       expect(res11[1]).to.be.equal(fixture.result1[0]);
@@ -57,6 +63,7 @@ describe('Definitions', () => {
       expect(res12[4]).to.be.equal(fixture.result2[3]);
     });
   });
+
   describe('Primitive data', () => {
     it('should create simple valid primitive table', () => {
       expect(res13[3]).to.be.equal(fixture.result3[0]);

--- a/tests/transformers/definitionsFixture.js
+++ b/tests/transformers/definitionsFixture.js
@@ -67,6 +67,15 @@ const fixture = {
   },
   result3: [
     '| deviceid | integer | DeviceID |  |'
+  ],
+  data4: {
+    Pet: {
+      description: 'This\nis\na\nvery\nlong\ndescription',
+      type: 'string',
+    }
+  },
+  result4: [
+    '| Pet | string | This is a very long description |  |'
   ]
 };
 fixture.defHeader1 = '#### Tag';


### PR DESCRIPTION
This PR will fix the conversion of the following example definition:
```json
{
  "Pet": {
    "description": "This\nis\na\nvery\nlong\ndescription",
    "type": "string"
  },
}
```

**Before**

![Screenshot before](https://user-images.githubusercontent.com/5497598/57854877-9016a800-77e9-11e9-8c11-4a4fe26ceb40.png)


**After**

![Screenshot after](https://user-images.githubusercontent.com/5497598/57854884-960c8900-77e9-11e9-8ec5-f50d19d117f4.png)

... and fixes two typos, too.