### PR TITLE
fix: security types should handle objects

### DIFF
--- a/app/transformers/securityDefinitions.js
+++ b/app/transformers/securityDefinitions.js
@@ -26,7 +26,7 @@ module.exports = securityDefinitions => {
           res.push(`|${scope}|`
             + `${securityDefinitions[type][value][scope].replace(/[\r\n]/g, ' ')}|`);
         });
-      } else if (value !== 'type') {
+      } else if (value !== 'type' && securityDefinitions[type][value].replace) {
         res.push(`|${nameResolver[value]}|`
           + `${securityDefinitions[type][value].replace(/[\r\n]/g, ' ')}|`);
       }


### PR DESCRIPTION
Closes #98 

When a security definition value is an object, it should still be rendered instead of throwing an exception. This is needed to support `x-amazon-apigateway-authorizer`.