### PR TITLE
feat: resolve multiple properties with allOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ You can also use it as a npm script in your package.json:
 
     npm i --save-dev swagger-markdown
 
-```json
+```jsonc
 {
     "scripts": {
         "md-docs": "swagger-markdown -i path/to/swagger.yaml",
-        ...
+        //...
     }
 }
 ```

--- a/app/models/schema.js
+++ b/app/models/schema.js
@@ -18,6 +18,9 @@ class Schema {
       if ('items' in schema) {
         this.setItems(schema.items);
       }
+      if ('allOf' in schema) {
+        this.setAllOf(schema.allOf);
+      }
     }
   }
 
@@ -26,6 +29,14 @@ class Schema {
    */
   setType(type) {
     this.type = type;
+    return this;
+  }
+
+  /**
+   * @param {Array<Object>} allOf
+   */
+  setAllOf(allOf) {
+    this.allOf = allOf.map(schema => new Schema(schema));
     return this;
   }
 
@@ -79,6 +90,13 @@ class Schema {
    */
   getReference() {
     return this.ref;
+  }
+
+  /**
+   * @return {Array<Schema>}
+   */
+  getAllOf() {
+    return this.allOf;
   }
 }
 

--- a/app/transformers/dataTypes.js
+++ b/app/transformers/dataTypes.js
@@ -23,7 +23,13 @@ const resolver = {
  * @param {Schema} schema
  * @return {String}
  */
-const dataTypeResoler = schema => {
+const dataTypeResolver = schema => {
+  if (schema.getAllOf()) {
+    return schema.getAllOf()
+      .map(subSchema => dataTypeResolver(subSchema))
+      .filter(type => type !== '')
+      .join(' & ');
+  }
   if (schema.getReference()) {
     const name = schema.getReference().match(/\/([^/]*)$/i)[1];
     const link = anchor(name);
@@ -41,7 +47,7 @@ const dataTypeResoler = schema => {
     return `${schema.getType()} (${schema.getFormat()})`;
   }
   if (schema.getType() === 'array') {
-    const subType = dataTypeResoler(schema.getItems());
+    const subType = dataTypeResolver(schema.getItems());
     return `[ ${subType} ]`;
   }
   if (schema.getType()) {
@@ -50,4 +56,4 @@ const dataTypeResoler = schema => {
   return '';
 };
 
-module.exports = dataTypeResoler;
+module.exports = dataTypeResolver;

--- a/tests/transformers/pathParameters.spec.js
+++ b/tests/transformers/pathParameters.spec.js
@@ -7,7 +7,7 @@ const tableFixture = [
   '| ---- | ---------- | ----------- | -------- | ---- |'
 ];
 
-describe('Path parameters transormer', () => {
+describe('Path parameters transformer', () => {
   describe('Method parameters', () => {
     const fixture = [
       {

--- a/tests/transformers/pathResponses.spec.js
+++ b/tests/transformers/pathResponses.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const respones = require('../../app/transformers/pathResponses');
+const responses = require('../../app/transformers/pathResponses');
 
 describe('Path responses transformer', () => {
   describe('no schemas', () => {
@@ -14,7 +14,7 @@ describe('Path responses transformer', () => {
       '| 200 | 200 |',
       '| 404 |  |'
     ];
-    const res = respones(fixture).split('\n');
+    const res = responses(fixture).split('\n');
 
     it('should build the header', () => {
       expect(res[0]).to.be.equal(results[0]);
@@ -51,7 +51,7 @@ describe('Path responses transformer', () => {
       '| 404 | Not Found |  |',
       '| 500 |  |  |'
     ];
-    const res = respones(fixture).split('\n');
+    const res = responses(fixture).split('\n');
 
     it('should build the header', () => {
       expect(res[0]).to.be.equal(results[0]);
@@ -82,7 +82,7 @@ describe('Path responses transformer', () => {
       '| 200 |  |  |',
       '| 404 |  | [Bar](#bar) |'
     ];
-    const res = respones(fixture).split('\n');
+    const res = responses(fixture).split('\n');
     it('should build the header', () => {
       expect(res[0]).to.be.equal(results[0]);
     });


### PR DESCRIPTION
Given the following schema in a parameter:

```json
"schema": {
  "allOf": [
    {
      "properties": {
        "conversationId": {
          "format": "uuid",
          "type": "string"
        }
      },
      "required": ["conversationId"],
      "type": "object"
    },
    {
      "$ref": "#/definitions/Confirmation"
    }
  ]
}
```

---

**Before**

![before](https://user-images.githubusercontent.com/5497598/58813818-da3ebc80-8624-11e9-8cf6-9f55933c7685.png)

**After**

![after](https://user-images.githubusercontent.com/5497598/58813832-df9c0700-8624-11e9-9e81-7b78b78d8ac9.png)
