### PR TITLE
feat: use swagger-parser to resolve $refs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,11 @@
     "no-unused-expressions": 0,
     "no-plusplus": 0,
     "arrow-parens": 0,
-    "no-confusing-arrow": 0
+    "no-confusing-arrow": 0,
+    "no-restricted-syntax": [
+      "error",
+      "LabeledStatement",
+      "WithStatement"
+    ]
   }
 }

--- a/app/convert.js
+++ b/app/convert.js
@@ -1,0 +1,85 @@
+const SwaggerParser = require('swagger-parser');
+const fs = require('fs');
+
+const transformInfo = require('./transformers/info');
+const transformPath = require('./transformers/path');
+const transformSecurityDefinitions = require('./transformers/securityDefinitions');
+const transformExternalDocs = require('./transformers/externalDocs');
+const transformDefinition = require('./transformers/definitions');
+
+// replace all $refs except model definitions as these have their own section in the doc
+function partiallyDereference(node, $refs) {
+  if (typeof node !== 'object') return node;
+  const obj = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (Array.isArray(value)) {
+      obj[key] = value.map(item => partiallyDereference(item, $refs));
+    } else if (key === '$ref' && !value.startsWith('#/definitions/')) {
+      return partiallyDereference($refs.get(value), $refs);
+    } else {
+      obj[key] = partiallyDereference(value, $refs);
+    }
+  }
+  return obj;
+}
+
+function transformSwagger(inputDoc, options = {}) {
+  const document = [];
+
+  // Collect parameters
+  const parameters = 'parameters' in inputDoc ? inputDoc.parameters : {};
+
+  // Process info
+  if (!options.skipInfo && 'info' in inputDoc) {
+    document.push(transformInfo(inputDoc.info));
+  }
+
+  if ('externalDocs' in inputDoc) {
+    document.push(transformExternalDocs(inputDoc.externalDocs));
+  }
+
+  // Security definitions
+  if ('securityDefinitions' in inputDoc) {
+    document.push(transformSecurityDefinitions(inputDoc.securityDefinitions));
+  } else if (inputDoc.components && inputDoc.components.securitySchemas) {
+    document.push(transformSecurityDefinitions(inputDoc.components.securityDefinitions));
+  }
+
+  // Process Paths
+  if ('paths' in inputDoc) {
+    Object.keys(inputDoc.paths).forEach(path => document.push(transformPath(
+      path,
+      inputDoc.paths[path],
+      parameters
+    )));
+  }
+
+  // Models (definitions)
+  if ('definitions' in inputDoc) {
+    document.push(transformDefinition(inputDoc.definitions));
+  } else if (inputDoc.components && inputDoc.components.schemas) {
+    document.push(transformDefinition(inputDoc.components.schemas));
+  }
+
+  return document.join('\n');
+}
+
+function transformFile(options) {
+  const swaggerParser = new SwaggerParser();
+  return swaggerParser.resolve(options.input).then(() => {
+    const dereferencedSwagger = partiallyDereference(swaggerParser.api, swaggerParser.$refs);
+    const markdown = transformSwagger(dereferencedSwagger, options);
+
+    if (options.output) {
+      fs.writeFileSync(options.output, markdown);
+    }
+
+    return markdown;
+  });
+}
+
+module.exports = {
+  transformFile,
+  transformSwagger,
+  partiallyDereference,
+};

--- a/app/transformers/pathParameters.js
+++ b/app/transformers/pathParameters.js
@@ -1,44 +1,36 @@
 const transformDataTypes = require('./dataTypes');
 const Schema = require('../models/schema');
 
-module.exports = (parameters, pathParameters, globalParameters = {}) => {
+module.exports = (parameters, pathParameters) => {
   const res = [];
   res.push('##### Parameters\n');
   res.push('| Name | Located in | Description | Required | Schema |');
   res.push('| ---- | ---------- | ----------- | -------- | ---- |');
   [].concat(pathParameters, parameters).map(keys => {
     if (keys) {
-      let parametersKeys = keys;
-      // Check it for the reference
-      if ('$ref' in keys) {
-        const ref = (keys.$ref).replace(/^#\/parameters\//, '');
-        if (ref in globalParameters) {
-          parametersKeys = globalParameters[ref];
-        }
-      }
       const line = [];
       // Name first
-      line.push(parametersKeys.name || '');
+      line.push(keys.name || '');
       // Scope (in)
-      line.push(parametersKeys.in || '');
+      line.push(keys.in || '');
       // description
-      if ('description' in parametersKeys) {
-        line.push(parametersKeys.description.replace(/[\r\n]/g, ' '));
+      if ('description' in keys) {
+        line.push(keys.description.replace(/[\r\n]/g, ' '));
       } else {
         line.push('');
       }
-      line.push(parametersKeys.required ? 'Yes' : 'No');
+      line.push(keys.required ? 'Yes' : 'No');
 
       // Prepare schema to be transformed
       let schema = null;
-      if ('schema' in parametersKeys) {
-        schema = new Schema(parametersKeys.schema);
+      if ('schema' in keys) {
+        schema = new Schema(keys.schema);
       } else {
         schema = new Schema();
-        schema.setType('type' in parametersKeys ? parametersKeys.type : null);
-        schema.setFormat('format' in parametersKeys ? parametersKeys.format : null);
-        schema.setReference('$ref' in parametersKeys ? parametersKeys.$ref : null);
-        schema.setItems('items' in parametersKeys ? parametersKeys.items : null);
+        schema.setType('type' in keys ? keys.type : null);
+        schema.setFormat('format' in keys ? keys.format : null);
+        schema.setReference('$ref' in keys ? keys.$ref : null);
+        schema.setItems('items' in keys ? keys.items : null);
       }
 
       line.push(transformDataTypes(schema));

--- a/package-lock.json
+++ b/package-lock.json
@@ -2227,8 +2227,7 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -2566,8 +2565,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commitizen": {
       "version": "4.0.3",
@@ -5718,6 +5716,16 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.2.tgz",
+      "integrity": "sha512-bi2Nns2UqdX7wThX5qSHd+lOxlu9oeJvlCnWGuR3qS4Ex4UZtuwygkyq/43J31GuNGX8xBHeV6zjQztYk/G5VA==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^5.1.0"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5999,8 +6007,12 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -10389,6 +10401,21 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "ono": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
+      "integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
+    },
+    "openapi-schemas": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
+      "integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
+    },
+    "openapi-types": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
+      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -11870,6 +11897,25 @@
         }
       }
     },
+    "swagger-methods": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
+      "integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
+    },
+    "swagger-parser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
+      "integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "json-schema-ref-parser": "^7.1.1",
+        "ono": "^5.1.0",
+        "openapi-schemas": "^1.0.2",
+        "openapi-types": "^1.3.5",
+        "swagger-methods": "^2.0.1",
+        "z-schema": "^4.1.1"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -12208,6 +12254,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
     },
     "which": {
       "version": "1.3.1",
@@ -12618,6 +12669,17 @@
         "property-expr": "^1.5.0",
         "synchronous-promise": "^2.0.6",
         "toposort": "^2.0.2"
+      }
+    },
+    "z-schema": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
+      "integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^11.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
-    "js-yaml": "^3.13.1"
+    "swagger-parser": "^8.0.3"
   }
 }

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -1,0 +1,56 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const { transformFile, partiallyDereference } = require('../app/convert');
+
+describe('Integration test examples', () => {
+  const examplesDir = `${__dirname}/../examples`;
+  const examples = fs.readdirSync(examplesDir);
+  examples
+    .filter(example => example.endsWith('.yaml'))
+    .map(example => example.substr(0, example.length - 5))
+    .forEach(example => {
+      it(`converts ${example}.yaml`, async () => {
+        const generated = await transformFile({ input: `${examplesDir}/${example}.yaml` });
+        const expected = fs.readFileSync(`${__dirname}/../examples/${example}.md`, 'utf8');
+        expect(generated).to.eql(expected);
+      });
+    });
+});
+
+describe('Partial dereference', () => {
+  const mockRefs = {
+    get(ref) {
+      switch (ref) {
+        case '#/some/thing':
+          return { some: 'thing' };
+        case '#/definitions/not/used':
+          return { not: 'used' };
+        case '#/transitive/ref':
+          return { transitive: { $ref: '#/some/thing' } };
+        default:
+          return null;
+      }
+    },
+  };
+
+  it('makes no changes to object with no $refs', () => {
+    const input = { one: { two: [3, 'four', { five: 'six' }] } };
+    expect(partiallyDereference(input)).to.eql(input);
+  });
+
+  it('dereferences $refs', () => {
+    const input = {
+      one: { two: [3, 'four', { $ref: '#/some/thing' }] },
+      five: { $ref: '#/some/thing' },
+      six: { seven: { $ref: '#/transitive/ref' } },
+      eight: { $ref: '#/definitions/not/used' },
+    };
+    const expected = {
+      one: { two: [3, 'four', { some: 'thing' }] },
+      five: { some: 'thing' },
+      six: { seven: { transitive: { some: 'thing' } } },
+      eight: { $ref: '#/definitions/not/used' },
+    };
+    expect(partiallyDereference(input, mockRefs)).to.eql(expected);
+  });
+});

--- a/tests/transformers/pathParameters.spec.js
+++ b/tests/transformers/pathParameters.spec.js
@@ -113,45 +113,4 @@ describe('Path parameters transformer', () => {
       });
     });
   });
-
-  describe('Path and references', () => {
-    const methodFixture = [{
-      name: 'method name',
-      in: 'formData',
-      description: 'name',
-      type: 'string'
-    }];
-    const pathFixture = [{
-      $ref: '#/parameters/test'
-    }];
-    const globalFixture = {
-      test: {
-        name: 'path name',
-        in: 'formData',
-        description: 'name',
-        type: 'string'
-      }
-    };
-    const results = [].concat(tableFixture, [
-      '| path name | formData | name | No | string |',
-      '| method name | formData | name | No | string |'
-    ]);
-
-    const res = parameters(methodFixture, pathFixture, globalFixture)
-      .split('\n');
-
-    it('Should create parameters header', () => {
-      expect(res[0]).to.be.equal(results[0]);
-    });
-
-    it('Should create table header', () => {
-      expect(res[2]).to.be.equal(results[1]);
-      expect(res[3]).to.be.equal(results[2]);
-    });
-
-    it('Should create table body', () => {
-      expect(res[4]).to.be.equal(results[3]);
-      expect(res[5]).to.be.equal(results[4]);
-    });
-  });
 });

--- a/tests/transformers/securityDefinitions.spec.js
+++ b/tests/transformers/securityDefinitions.spec.js
@@ -1,18 +1,18 @@
 const { expect } = require('chai');
-const transformSecurituDefinitions = require('../../app/transformers/securityDefinitions');
+const transformSecurityDefinitions = require('../../app/transformers/securityDefinitions');
 const { nameResolver } = require('../../app/transformers/securityDefinitions');
 const { typeResolver } = require('../../app/transformers/securityDefinitions');
 
 describe('Security definitions', () => {
   it('Should not create any data if definitions is empty', () => {
     const fixture = {};
-    const res = transformSecurituDefinitions(fixture);
+    const res = transformSecurityDefinitions(fixture);
     expect(res).to.be.equal(null);
   });
   it('Should resolve auth type', () => {
     Object.keys(typeResolver).map(type => {
       const fixture = { auth: { type } };
-      const res = transformSecurituDefinitions(fixture);
+      const res = transformSecurityDefinitions(fixture);
       const result = '### Security\n'
         + '**auth**  \n\n'
         + `|${type}|*${typeResolver[type]}*|\n`
@@ -24,7 +24,7 @@ describe('Security definitions', () => {
     Object.keys(nameResolver).map(key => {
       const fixture = { auth: { type: 'basic' } };
       fixture.auth[key] = 'value';
-      const res = transformSecurituDefinitions(fixture);
+      const res = transformSecurityDefinitions(fixture);
       const result = `|${nameResolver[key]}|value|\n`;
       expect(res).to.include(result);
     });
@@ -39,7 +39,7 @@ describe('Security definitions', () => {
         }
       }
     };
-    const res = transformSecurituDefinitions(fixture);
+    const res = transformSecurityDefinitions(fixture);
     expect(res).to.exist;
   });
   it('Should ignore undefined keys unless it is prefixed with x-', () => {
@@ -51,7 +51,7 @@ describe('Security definitions', () => {
         'unknown-key': 'Uknown key',
       }
     };
-    const result = transformSecurituDefinitions(fixture);
+    const result = transformSecurityDefinitions(fixture);
     expect(result.match(/undefined/ig)).to.be.null;
     expect(result.match(/x-special-key/ig)).to.be.not.null;
   });


### PR DESCRIPTION
- Don't resolve refs to definitions since these have their own section in the generated docs
- Split up index.js to make it more testable
- Add integration tests to verify that examples convert correctly - I wanted to do this for my own peace of mind but it seems useful for others too
- Relax Airbnb lint rules to allow for..of - `.forEach` doesn't work in this instance because I need to return early if I find a `$ref` key (which means any sibling keys are lost but this is [as per the spec](https://swagger.io/docs/specification/using-ref/))

Fixes #84. 

I didn't use the built in `dereference` method of [`swagger-parser`](https://www.npmjs.com/package/swagger-parser) because this makes the internal links to model definitions stop working. Instead I use the parser to collect up all the refs then I walk the spec object and only replace some refs. This replaces the existing special case handling of refs in path parameters.
