### PR TITLE
feat: append schema example and enum values to description

### DIFF
--- a/app/transformers/definitions.js
+++ b/app/transformers/definitions.js
@@ -13,7 +13,18 @@ const parseProperties = (name, definition) => {
   Object.keys(definition.properties).map(propName => {
     const prop = definition.properties[propName];
     const typeCell = dataTypeTransformer(new Schema(prop));
-    const descriptionCell = ('description' in prop ? prop.description : '').replace(/[\r\n]/g, ' ');
+    const descriptionParts = [];
+    if ('description' in prop) {
+      descriptionParts.push(prop.description.replace(/[\r\n]/g, ' '));
+    }
+    if ('enum' in prop) {
+      const enumValues = prop.enum.map(val => `\`${JSON.stringify(val)}\``).join(', ');
+      descriptionParts.push(`_Enum:_ ${enumValues}`);
+    }
+    if ('example' in prop) {
+      descriptionParts.push(`_Example:_ \`${JSON.stringify(prop.example)}\``);
+    }
+    const descriptionCell = descriptionParts.join('<br>');
     const requiredCell = inArray(propName, required) ? 'Yes' : 'No';
     res.push(`| ${propName} | ${typeCell} | ${descriptionCell} | ${requiredCell} |`);
   });

--- a/examples/petstore_full.md
+++ b/examples/petstore_full.md
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 | ---- | ---- | ----------- | -------- |
 | id | long |  | No |
 | category | [Category](#category) |  | No |
-| name | string |  | Yes |
+| name | string | _Example:_ `"doggie"` | Yes |
 | photoUrls | [ string ] |  | Yes |
 | tags | [ [Tag](#tag) ] |  | No |
 | status | string | pet status in the store | No |

--- a/tests/transformers/definitions.spec.js
+++ b/tests/transformers/definitions.spec.js
@@ -14,28 +14,28 @@ describe('Definitions', () => {
   const res41 = res4.slice(-1);
 
   it('should create model header', () => {
-    expect(fixture.definitionsHeader[0]).to.be.equal(res1[0]);
-    expect(fixture.definitionsHeader[0]).to.be.equal(res2[0]);
-    expect(fixture.definitionsHeader[0]).to.be.equal(res3[0]);
+    expect(res1[0]).to.be.equal(fixture.definitionsHeader[0]);
+    expect(res2[0]).to.be.equal(fixture.definitionsHeader[0]);
+    expect(res3[0]).to.be.equal(fixture.definitionsHeader[0]);
   });
 
   it('should create proper header', () => {
-    expect(fixture.defHeader1).to.be.equal(res1[3]);
-    expect(fixture.defHeader2).to.be.equal(res2[3]);
-    expect(fixture.defHeader3).to.be.equal(res3[3]);
+    expect(res1[3]).to.be.equal(fixture.defHeader1);
+    expect(res2[3]).to.be.equal(fixture.defHeader2);
+    expect(res3[3]).to.be.equal(fixture.defHeader3);
   });
 
   it('should create table headers', () => {
-    expect(fixture.tableHeader[0]).to.be.equal(res1[5]);
-    expect(fixture.tableHeader[1]).to.be.equal(res1[6]);
-    expect(fixture.tableHeader[0]).to.be.equal(res2[5]);
-    expect(fixture.tableHeader[1]).to.be.equal(res2[6]);
-    expect(fixture.tableHeader[0]).to.be.equal(res3[7]);
-    expect(fixture.tableHeader[1]).to.be.equal(res3[8]);
+    expect(res1[5]).to.be.equal(fixture.tableHeader[0]);
+    expect(res1[6]).to.be.equal(fixture.tableHeader[1]);
+    expect(res2[5]).to.be.equal(fixture.tableHeader[0]);
+    expect(res2[6]).to.be.equal(fixture.tableHeader[1]);
+    expect(res3[7]).to.be.equal(fixture.tableHeader[0]);
+    expect(res3[8]).to.be.equal(fixture.tableHeader[1]);
   });
 
   it('should also create description', () => {
-    expect(fixture.data3.deviceid.description).to.be.equal(res3[5]);
+    expect(res3[5]).to.be.equal(fixture.data3.deviceid.description);
   });
 
   it('should create a single description line', () => {
@@ -53,7 +53,7 @@ describe('Definitions', () => {
     it('should add reference to other definition', () => {
       expect(res12[1]).to.be.equal(fixture.result2[0]);
     });
-    it('should add description', () => {
+    it('should add description and example', () => {
       expect(res12[2]).to.be.equal(fixture.result2[1]);
     });
     it('should render types as an array', () => {
@@ -61,6 +61,9 @@ describe('Definitions', () => {
     });
     it('should render array of references', () => {
       expect(res12[4]).to.be.equal(fixture.result2[3]);
+    });
+    it('should add enum values', () => {
+      expect(res12[5]).to.be.equal(fixture.result2[4]);
     });
   });
 

--- a/tests/transformers/definitionsFixture.js
+++ b/tests/transformers/definitionsFixture.js
@@ -48,15 +48,20 @@ const fixture = {
           items: {
             $ref: '#/definitions/Category'
           }
-        }
+        },
+        gender: {
+          type: 'string',
+          enum: ['male', 'female']
+        },
       }
     }
   },
   result2: [
     '| category | [Category](#category) |  | No |',
-    '| name | string | pet category in the store | Yes |',
+    '| name | string | pet category in the store<br>_Example:_ `"doggie"` | Yes |',
     '| photoUrls | [ string ] |  | Yes |',
-    '| tags | [ [Category](#category) ] |  | No |'
+    '| tags | [ [Category](#category) ] |  | No |',
+    '| gender | string | _Enum:_ `"male"`, `"female"` | No |'
   ],
   data3: {
     deviceid: {


### PR DESCRIPTION
This is similar to the way the official Swagger UI renders schemas: 

![Screen Shot 2019-12-05 at 14 07 10](https://user-images.githubusercontent.com/115310/70242366-9f027f00-1768-11ea-90cb-14401ccbdd2f.png)

Also switched a few assertions so that `actual` and `expected` are the right way around.