### PR TITLE
fix(partiallyDereference): shallow copy node

### DIFF
--- a/app/convert.js
+++ b/app/convert.js
@@ -14,7 +14,7 @@ const markdownlintConfig = require('../.markdownlint.json');
 function partiallyDereference(node, $refs) {
   if (typeof node !== 'object') return node;
   const obj = {};
-  for (const [key, value] of Object.entries(node)) {
+  for (const [key, value] of Object.entries({ ...node })) {
     if (Array.isArray(value)) {
       obj[key] = value.map(item => partiallyDereference(item, $refs));
     } else if (key === '$ref' && !value.startsWith('#/definitions/')) {


### PR DESCRIPTION
I have no clue why, but when pulling the latest version of `swagger-markdown`, the build fails with this error:

```
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at partiallyDereference (xxx/node_modules/swagger-markdown/bin/convert.js:47:26)
    at partiallyDereference (xxx/node_modules/swagger-markdown/bin/convert.js:43:20)
    at xxx/node_modules/swagger-markdown/bin/convert.js:38:18
    at Array.map (<anonymous>)
    at partiallyDereference (xxx/node_modules/swagger-markdown/bin/convert.js:37:26)
    at xxx/node_modules/swagger-markdown/bin/convert.js:38:18
    at Array.map (<anonymous>)
    at partiallyDereference (xxx/node_modules/swagger-markdown/bin/convert.js:37:26)
    at partiallyDereference (xxx/node_modules/swagger-markdown/bin/convert.js:43:20)
```

The issue is on `Object.entries(node)`, but logging it shows that it's neither `null` or `undefined`, it's the complete API.
I don't know why, but it seems like `swaggerParser.api` is not a regular object, all I know is that adding this line before the call to `Object.entries` fixed the issue:

```js
node = Object.assign({}, node);
```